### PR TITLE
Don't .npmignore the README

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-*.md
 .git*
 examples/
 just.min.js


### PR DESCRIPTION
Not having a README results in a warning in npm, and means that no readme is displayed on npmjs.org
